### PR TITLE
Downgrade Sphinx to 6.2.1

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,4 @@
+.bd-sidebar-primary div#rtd-footer-container {
+    margin-top: 0px !important;
+    margin-bottom: 0px !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,10 +56,12 @@ html_theme = 'sphinx_book_theme'
 html_theme_options = {
     'repository_url': 'https://github.com/Lang-SIG/LangSIG',
     'use_download_button': False,
+    'navigation_with_keys': False
 }
-html_sidebars = {
-    "**": []
-}
+html_css_files = [
+    'css/custom.css',
+]
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==7.1.2
+Sphinx==6.2.1
 sphinx-book-theme==1.0.1


### PR DESCRIPTION
* Remove navigation_with_keys deprecation warning
* Remove pointless scrollbar on sidebar by [some CSS Hack](https://github.com/executablebooks/sphinx-book-theme/issues/732#issuecomment-1802597436)